### PR TITLE
Put back exception response for forbidden domains.

### DIFF
--- a/src/Core/Controller/DefaultController.php
+++ b/src/Core/Controller/DefaultController.php
@@ -30,6 +30,8 @@ class DefaultController extends CoreController
         } catch (\Exception $e) {
             $imageContent = null;
             $image->unlinkUsedFiles();
+            $formattedMessage = '<pre>' . $e->getMessage() . '</pre>';
+            return new Response($formattedMessage, Response::HTTP_FORBIDDEN);
         }
 
         return $this->generateImageResponse($image, $imageContent);


### PR DESCRIPTION
I was getting errors when trying to get an image from a restricted domain with `restricted_domains: true`

See screenshot:
![screen shot 2017-01-22 at 22 50 23](https://cloud.githubusercontent.com/assets/836077/22186591/209bfba4-e0f8-11e6-92e7-fb325fc13cdd.png)

It was allowing the app to try and create a file that was not there. Also trying to get the image's info when requesting with `refresh:1` and failing with the previous error.

If the resource was requested without refresh it returned and empty `http 200`
