### PR TITLE
Partial PNG support.

### DIFF
--- a/src/Core/Controller/CoreController.php
+++ b/src/Core/Controller/CoreController.php
@@ -46,6 +46,7 @@ class CoreController
     {
         $response->headers->set('Content-Type', $image->getResponseContentType());
 
+        /** @todo: move all this cache header logic to its own method  */
         $expireDate = new \DateTime();
         $expireDate->add(new \DateInterval('P1Y'));
         $response->setExpires($expireDate);
@@ -59,7 +60,7 @@ class CoreController
             $response->headers->set('Cache-Control', 'no-cache, private');
             $response->setExpires(null)->expire();
 
-            $response->headers->set('im-identify', $this->app['image.processor']->getImageIdentity($image));
+            $response->headers->set('im-identify', $image->getInfo());
             $response->headers->set('im-command', $image->getCommandString());
         }
         return $response;


### PR DESCRIPTION
Added an identify method but need review.

## Does not work with webP enabled
this url `http://192.168.96.100:8080/upload/w_601,h_601,rf_1/https://raw.githubusercontent.com/flyimg/graphic-assets/master/logo/raster/flyimg-logo-rgb.png`
will throw

`The last line of output: /usr/bin/convert /var/www/html/var/tmp/588fdbd8ec3d38.74595512 -thumbnail 601x601\> -gravity Center -extent 601x601+repage  -colorspace sRGB -limit thread '1' -strip  -filter 'Lanczos' -sampling-factor '1x1' -quality '90' '/var/www/html/var/tmp/2dd91029ea511b906ac262d82768bd5b-588fdbd8f33cd4.11918861.webp'`