### PR TITLE
Allow to serve WebP if explicitly requested

### DIFF
--- a/config/parameters.yml
+++ b/config/parameters.yml
@@ -3,8 +3,8 @@ application_name: Flyimg.io
 #debug
 debug: true
 
-#WebP support Enabled
-webp_enabled: false
+#Serve WebP automatically to Browsers supporting it
+auto_webp_enabled: false
 
 #Number of days for header cache expires `max_age`
 header_cache_days: 365

--- a/src/Core/Entity/Image.php
+++ b/src/Core/Entity/Image.php
@@ -241,14 +241,21 @@ class Image
     }
 
     /**
+     * Return bollean stating if WebP image format is supported; following these conditions:
+     *  - The request is specifically expecting a webP response, independent of the browser's capabilities
+     *  OR both:
+     *  - The browser sent headers explicitly stating it supports webp (absolute requirement)
+     *  AND
+     *  - The app config/parameters.yml states that auto webP serving is enabled
+     *
      * @return bool
      */
     public function isWebPSupport()
     {
-        return in_array(self::WEBP_MIME_TYPE, Request::createFromGlobals()->getAcceptableContentTypes())
-            && ($this->defaultParams['webp_enabled'] || $this->outputExtension == self::EXT_WEBP);
+        return $this->outputExtension == self::EXT_WEBP
+            || (in_array(self::WEBP_MIME_TYPE, Request::createFromGlobals()->getAcceptableContentTypes())
+            && $this->defaultParams['auto_webp_enabled']);
     }
-
 
     /**
      * @return bool


### PR DESCRIPTION
Currently we only send a response with webp format if the headers state **webp** support, like Chrome.

We should serve WebP if explicitly requested, because it could be coming from a `wget` request or a `curl` request, that just wants the **WebP** format to store it or do something else.

Also updated the config name for enabling webP to `auto_webp_enabled` because it's what it does.

Today even with `webp_enabled` we can serve webp, which can be confusing.