### PR TITLE
added option to extract part of an image (manual crop _then_ resize)

### DIFF
--- a/config/parameters.yml
+++ b/config/parameters.yml
@@ -56,7 +56,11 @@ options_keys:
   pns: preserve-natural-size
   webpl: webp-lossless
   gf: gif-frame
-
+  e: extract
+  p1x: extract-top-x
+  p1y: extract-top-y
+  p2x: extract-bottom-x
+  p2y: extract-bottom-y
 
 #Default options values
 default_options:
@@ -84,5 +88,10 @@ default_options:
   preserve-natural-size: 1
   webp-lossless: 0
   gif-frame: 0
+  thread: 1,
+  extract: null
+  extract-top-x: null
+  extract-top-y: null
+  extract-bottom-x: null
+  extract-bottom-y: null
   # private options set here
-  thread: 1

--- a/src/Core/Service/ImageProcessor.php
+++ b/src/Core/Service/ImageProcessor.php
@@ -74,9 +74,14 @@ class ImageProcessor
      */
     protected function saveNewFile(Image $image)
     {
-        $faceCrop = $image->extract('face-crop');
+        $faceCrop         = $image->extract('face-crop');
         $faceCropPosition = $image->extract('face-crop-position');
-        $faceBlur = $image->extract('face-blur');
+        $faceBlur         = $image->extract('face-blur');
+        $extract          = $image->extract('extract');
+        $topLeftX     = $image->extract('extract-top-x');
+        $topLeftY     = $image->extract('extract-top-y');
+        $bottomRightX = $image->extract('extract-bottom-x');
+        $bottomRightY = $image->extract('extract-bottom-y');
 
         $this->generateCmdString($image);
 
@@ -86,6 +91,10 @@ class ImageProcessor
 
         if ($faceCrop && !$image->isGifSupport()) {
             $this->processCroppingFaces($image, $faceCropPosition);
+        }
+
+        if ($extract) {
+            $this->processExtraction($image, $topLeftX, $topLeftY, $bottomRightX, $bottomRightY);
         }
 
         $this->execute($image->getCommandString());
@@ -122,6 +131,28 @@ class ImageProcessor
                 $image->getTemporaryFile();
             $this->execute($cropCmdStr);
         }
+    }
+
+    /**
+     * Extracts a region from an image
+     *
+     * @param Image $image
+     * @param int   $topLeftX
+     * @param int   $topLeftY
+     * @param int   $bottomRightX
+     * @param int   $bottomRightY
+     */
+    protected function processExtraction(Image $image, $topLeftX, $topLeftY, $bottomRightX, $bottomRightY)
+    {
+        $geometryW = $bottomRightX - $topLeftX;
+        $geometryH = $bottomRightY - $topLeftY;
+
+        $cropCmdStr
+            = self::IM_CONVERT_COMMAND.
+              " '{$image->getTemporaryFile()}' -crop '{$geometryW}'x'{$geometryH}'+'{$topLeftX}'+'{$topLeftY}' ".
+              $image->getTemporaryFile();
+
+        $this->execute($cropCmdStr);
     }
 
     /**


### PR DESCRIPTION
Before I make a lot of work of creating a proper PR, did I miss something or is it not yet possible to do a crop and then a resize without this?

What I'm doing right now is upload an image to storage. The user can then put a box over the image (like this https://foliotek.github.io/Croppie/) and I save the coords for the white box (viewport) for generating the URLs.

Then I defined an nginx rule like this:

```
location ~ /image/(.+)x(.+)/(.+)_(.+)_(.+)_(.+)/(.+) {
    proxy_pass http://<IP FOR FLYIMG>/upload/w_$1,h_$2,e_1,p1x_$3,p1y_$4,p2x_$5,p2y_$6/http://<MY IMAGE STORAGE>/image/$7;
}
```

So 
```
http://mywebsite.zz/image/650x520/55_0_448_328/dd78aba6-8fcc-4cbc-91d7-c4777d6ba10f_0eaa14d11e8930f5.jpg
```
 becomes 
```
http://flyimg/upload/h_650,w_520,e_1,p1x_55,p1y_0,p2x_448,p2y_328/http://storage/image/dd78aba6-8fcc-4cbc-91d7-c4777d6ba10f_0eaa14d11e8930f5.jpg
```

Which will give me exactly what the user cropped in any height and width from the original.

I look forward to your feedback, maybe you know of an easier way or see trouble with this implementation.

