### PR TITLE
Refactor: Performance, structure and code improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,27 +470,27 @@ Requires: Vegeta [http://github.com/tsenart/vegeta](http://github.com/tsenart/ve
 ```
 Crop http://localhost:8080/upload/w_200,h_200,c_1,/Rovinj-Croatia.jpg
 Requests      [total, rate]            500, 50.10
-Duration      [total, attack, wait]    9.987040447s, 9.979999952s, 7.040495ms
-Latencies     [mean, 50, 95, 99, max]  30.374428ms, 7.118491ms, 198.48037ms, 403.203168ms, 667.636703ms
-Bytes In      [total, mean]            86208, 172.42
+Duration      [total, attack, wait]    9.986739873s, 9.97999984s, 6.740033ms
+Latencies     [mean, 50, 95, 99, max]  25.076911ms, 6.640774ms, 188.643721ms, 331.643374ms, 636.521662ms
+Bytes In      [total, mean]            213904, 427.81
 Bytes Out     [total, mean]            0, 0.00
 Success       [ratio]                  100.00%
 Status Codes  [code:count]             200:500
 
 Resize http://localhost:8080/upload/w_200,h_200,rz_1/Rovinj-Croatia.jpg
 Requests      [total, rate]            500, 50.10
-Duration      [total, attack, wait]    9.986398956s, 9.979999972s, 6.398984ms
-Latencies     [mean, 50, 95, 99, max]  14.058886ms, 7.27949ms, 26.480589ms, 218.968846ms, 289.695028ms
-Bytes In      [total, mean]            101675, 203.35
+Duration      [total, attack, wait]    9.987057007s, 9.979999967s, 7.05704ms
+Latencies     [mean, 50, 95, 99, max]  12.830654ms, 7.643809ms, 40.270126ms, 108.39337ms, 195.252615ms
+Bytes In      [total, mean]            77994, 155.99
 Bytes Out     [total, mean]            0, 0.00
 Success       [ratio]                  100.00%
 Status Codes  [code:count]             200:500
 
 Rotate http://localhost:8080/upload/r_-45,w_400,h_400/Rovinj-Croatia.jpg
 Requests      [total, rate]            500, 50.10
-Duration      [total, attack, wait]    10.851828209s, 9.97999994s, 871.828269ms
-Latencies     [mean, 50, 95, 99, max]  2.286214264s, 2.140216211s, 4.513043865s, 7.226125489s, 7.251871479s
-Bytes In      [total, mean]            987720, 1975.44
+Duration      [total, attack, wait]    9.986181761s, 9.979999903s, 6.181858ms
+Latencies     [mean, 50, 95, 99, max]  984.630622ms, 585.392512ms, 2.660701812s, 2.763049369s, 6.202687668s
+Bytes In      [total, mean]            1304682, 2609.36
 Bytes Out     [total, mean]            0, 0.00
 Success       [ratio]                  100.00%
 Status Codes  [code:count]             200:500

--- a/app.php
+++ b/app.php
@@ -71,7 +71,7 @@ $app['image.processor'] = function ($app) {
 
 /** Core Manager Service */
 $app['core.manager'] = function ($app) {
-    return new CoreManager($app['image.processor'], $app['params']);
+    return new CoreManager($app['image.processor'], $app['params'], $app['flysystems']['upload_dir']);
 };
 
 /** debug conf */

--- a/src/Core/Service/CoreManager.php
+++ b/src/Core/Service/CoreManager.php
@@ -56,10 +56,11 @@ class CoreManager
     }
 
     /**
-     * @param $options
-     * @param $imageSrc
+     * @param string $options
+     * @param string $imageSrc
      *
      * @return Image
+     * @throws \Exception
      */
     public function processImage(string $options, string $imageSrc): Image
     {
@@ -68,7 +69,6 @@ class CoreManager
         $image = new Image($parsedOptions, $imageSrc);
 
         try {
-
             if ($this->filesystem->has($image->getNewFileName()) && $image->getOptions()['refresh']) {
                 $this->filesystem->delete($image->getNewFileName());
             }

--- a/tests/Core/BaseTest.php
+++ b/tests/Core/BaseTest.php
@@ -70,5 +70,4 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf('Silex\Application', $this->app);
     }
-
 }

--- a/tests/Core/BaseTest.php
+++ b/tests/Core/BaseTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tests\Core;
 
 use Core\Entity\Image;
@@ -17,15 +18,16 @@ class BaseTest extends \PHPUnit_Framework_TestCase
      * @var Application
      */
     protected $app = null;
-    /**
-     * @var Image
-     */
-    protected $image = null;
 
     /**
      * @var CoreManager
      */
     protected $coreManager = null;
+
+    /**
+     * @var array
+     */
+    protected $generatedImage = [];
 
     /**
      *
@@ -34,8 +36,6 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     {
         $this->app = $this->createApplication();
         $this->coreManager = $this->app['core.manager'];
-        $parsedOptions = $this->coreManager->parse(self::OPTION_URL);
-        $this->image = new Image($parsedOptions, self::JPG_TEST_IMAGE);
     }
 
     /**
@@ -43,11 +43,11 @@ class BaseTest extends \PHPUnit_Framework_TestCase
      */
     protected function tearDown()
     {
-        if (file_exists($this->image->getNewFilePath())) {
-            unlink($this->image->getNewFilePath());
-        }
-        if (file_exists($this->image->getTemporaryFile())) {
-            unlink($this->image->getTemporaryFile());
+        foreach ($this->generatedImage as $image) {
+            if (!$image instanceof Image) {
+                continue;
+            }
+            $image->unlinkUsedFiles(true);
         }
     }
 
@@ -71,10 +71,4 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Silex\Application', $this->app);
     }
 
-    /**
-     */
-    public function testImageInstance()
-    {
-        $this->assertInstanceOf('Core\Entity\Image', $this->image);
-    }
 }

--- a/tests/Core/Entity/ImageTest.php
+++ b/tests/Core/Entity/ImageTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tests\Core\Entity;
 
 use Core\Entity\Image;
@@ -41,8 +42,11 @@ class ImageTest extends BaseTest
             'gif-frame' => '0',
             'thread' => '1',
         ];
+        $parsedOptions = $this->coreManager->parse(self::OPTION_URL);
+        $image = new Image($parsedOptions, self::JPG_TEST_IMAGE);
+        $this->generatedImage[] = $image;
 
-        $this->assertEquals($this->image->getOptions(), $expectedParseArray);
+        $this->assertEquals($image->getOptions(), $expectedParseArray);
     }
 
     /**
@@ -50,7 +54,11 @@ class ImageTest extends BaseTest
      */
     public function testSaveToTemporaryFile()
     {
-        $this->assertFileExists($this->image->getTemporaryFile());
+        $parsedOptions = $this->coreManager->parse(self::OPTION_URL);
+        $image = new Image($parsedOptions, self::JPG_TEST_IMAGE);
+        $this->generatedImage[] = $image;
+
+        $this->assertFileExists($image->getOriginalFile());
     }
 
     /**
@@ -59,7 +67,8 @@ class ImageTest extends BaseTest
     public function testSaveToTemporaryFileException()
     {
         $this->expectException(ReadFileException::class);
-        $this->image = new Image([], parent::JPG_TEST_IMAGE.'--fail');
+        $image = new Image(['output' => 'jpg'], parent::JPG_TEST_IMAGE.'--fail');
+        $this->generatedImage[] = $image;
     }
 
     /**
@@ -68,8 +77,14 @@ class ImageTest extends BaseTest
     public function testGenerateFilesName()
     {
         $image = new Image($this->coreManager->parse(parent::OPTION_URL), parent::JPG_TEST_IMAGE);
-        $this->assertEquals($this->image->getNewFileName(), $image->getNewFileName());
-        $this->assertNotEquals($this->image->getNewFilePath(), $image->getNewFilePath());
+        $parsedOptions = $this->coreManager->parse(self::OPTION_URL);
+        $image2 = new Image($parsedOptions, self::JPG_TEST_IMAGE);
+
+        $this->generatedImage[] = $image2;
+        $this->generatedImage[] = $image;
+
+        $this->assertEquals($image2->getNewFileName(), $image->getNewFileName());
+        $this->assertNotEquals($image2->getNewFilePath(), $image->getNewFilePath());
     }
 
     /**
@@ -77,7 +92,10 @@ class ImageTest extends BaseTest
      */
     public function testExtractByKey()
     {
-        $this->image->extract('width');
-        $this->assertFalse(array_key_exists('width', $this->image->getOptions()));
+        $parsedOptions = $this->coreManager->parse(self::OPTION_URL);
+        $image = new Image($parsedOptions, self::JPG_TEST_IMAGE);
+        $image->extract('width');
+        $this->generatedImage[] = $image;
+        $this->assertFalse(array_key_exists('width', $image->getOptions()));
     }
 }

--- a/tests/Core/Service/ImageProcessorTest.php
+++ b/tests/Core/Service/ImageProcessorTest.php
@@ -12,84 +12,94 @@ class ImageProcessorTest extends BaseTest
      */
     public function testProcessPNG()
     {
-        $this->image = $this->coreManager->processImage(parent::OPTION_URL.',o_png', parent::PNG_TEST_IMAGE);
-        $this->assertFileExists($this->image->getNewFilePath());
-        $this->assertEquals(Image::PNG_MIME_TYPE, $this->getFileMemeType($this->image->getNewFilePath()));
+        $image = $this->coreManager->processImage(parent::OPTION_URL.',o_png', parent::PNG_TEST_IMAGE);
+        $this->generatedImage[] = $image;
+        $this->assertFileExists($image->getNewFilePath());
+        $this->assertEquals(Image::PNG_MIME_TYPE, $this->getFileMemeType($image->getNewFilePath()));
     }
 
     /**
      */
     public function testProcessWebpFromPng()
     {
-        $this->image = $this->coreManager->processImage(parent::OPTION_URL.',o_webp', parent::PNG_TEST_IMAGE);
-        $this->assertFileExists($this->image->getNewFilePath());
-        $this->assertEquals(Image::WEBP_MIME_TYPE, $this->getFileMemeType($this->image->getNewFilePath()));
+        $image = $this->coreManager->processImage(parent::OPTION_URL.',o_webp', parent::PNG_TEST_IMAGE);
+        $this->generatedImage[] = $image;
+        $this->assertFileExists($image->getNewFilePath());
+        $this->assertEquals(Image::WEBP_MIME_TYPE, $this->getFileMemeType($image->getNewFilePath()));
     }
 
     /**
      */
     public function testProcessJpgFromPng()
     {
-        $this->image = $this->coreManager->processImage(parent::OPTION_URL.',o_jpg', parent::PNG_TEST_IMAGE);
-        $this->assertFileExists($this->image->getNewFilePath());
-        $this->assertEquals(Image::JPEG_MIME_TYPE, $this->getFileMemeType($this->image->getNewFilePath()));
+        $image = $this->coreManager->processImage(parent::OPTION_URL.',o_jpg', parent::PNG_TEST_IMAGE);
+        $this->generatedImage[] = $image;
+        $this->assertFileExists($image->getNewFilePath());
+        $this->assertEquals(Image::JPEG_MIME_TYPE, $this->getFileMemeType($image->getNewFilePath()));
     }
 
     /**
      */
     public function testProcessGifFromPng()
     {
-        $this->image = $this->coreManager->processImage(parent::OPTION_URL.',o_gif', parent::PNG_TEST_IMAGE);
-        $this->assertFileExists($this->image->getNewFilePath());
-        $this->assertEquals(Image::GIF_MIME_TYPE, $this->getFileMemeType($this->image->getNewFilePath()));
+        $image = $this->coreManager->processImage(parent::OPTION_URL.',o_gif', parent::PNG_TEST_IMAGE);
+        $this->generatedImage[] = $image;
+        $this->assertFileExists($image->getNewFilePath());
+        $this->assertEquals(Image::GIF_MIME_TYPE, $this->getFileMemeType($image->getNewFilePath()));
     }
 
     /**
      */
     public function testProcessJpg()
     {
-        $this->image = $this->coreManager->processImage(parent::OPTION_URL, parent::JPG_TEST_IMAGE);
-        $this->assertFileExists($this->image->getNewFilePath());
+        $image = $this->coreManager->processImage(parent::OPTION_URL, parent::JPG_TEST_IMAGE);
+        $this->generatedImage[] = $image;
+        $this->assertFileExists($image->getNewFilePath());
     }
 
     /**
      */
     public function testProcessGif()
     {
-        $this->image = $this->coreManager->processImage(parent::GIF_OPTION_URL, parent::GIF_TEST_IMAGE);
-        $this->assertFileExists($this->image->getNewFilePath());
-        $this->assertEquals(Image::GIF_MIME_TYPE, $this->getFileMemeType($this->image->getNewFilePath()));
+        $image = $this->coreManager->processImage(parent::GIF_OPTION_URL, parent::GIF_TEST_IMAGE);
+        $this->generatedImage[] = $image;
+        $this->assertFileExists($image->getNewFilePath());
+        $this->assertEquals(Image::GIF_MIME_TYPE, $this->getFileMemeType($image->getNewFilePath()));
     }
 
     /**
      */
     public function testProcessPngFromGif()
     {
-        $this->image = $this->coreManager->processImage(parent::GIF_OPTION_URL.',o_png', parent::GIF_TEST_IMAGE);
-        $this->assertFileExists($this->image->getNewFilePath());
-        $this->assertEquals(Image::PNG_MIME_TYPE, $this->getFileMemeType($this->image->getNewFilePath()));
+        $image = $this->coreManager->processImage(parent::GIF_OPTION_URL.',o_png', parent::GIF_TEST_IMAGE);
+        $this->generatedImage[] = $image;
+        $this->assertFileExists($image->getNewFilePath());
+        $this->assertEquals(Image::PNG_MIME_TYPE, $this->getFileMemeType($image->getNewFilePath()));
     }
 
     /**
      */
     public function testProcessJpgFromGif()
     {
-        $this->image = $this->coreManager->processImage(parent::GIF_OPTION_URL.',o_jpg', parent::GIF_TEST_IMAGE);
-        $this->assertFileExists($this->image->getNewFilePath());
-        $this->assertEquals(Image::JPEG_MIME_TYPE, $this->getFileMemeType($this->image->getNewFilePath()));
+        $image = $this->coreManager->processImage(parent::GIF_OPTION_URL.',o_jpg', parent::GIF_TEST_IMAGE);
+        $this->generatedImage[] = $image;
+        $this->assertFileExists($image->getNewFilePath());
+        $this->assertEquals(Image::JPEG_MIME_TYPE, $this->getFileMemeType($image->getNewFilePath()));
     }
 
     /**
      */
     public function testProcessWebpFromGif()
     {
-        $this->image = $this->coreManager->processImage(parent::GIF_OPTION_URL.',o_webp', parent::GIF_TEST_IMAGE);
-        $this->assertFileExists($this->image->getNewFilePath());
-        $this->assertEquals(Image::WEBP_MIME_TYPE, $this->getFileMemeType($this->image->getNewFilePath()));
+        $image = $this->coreManager->processImage(parent::GIF_OPTION_URL.',o_webp', parent::GIF_TEST_IMAGE);
+        $this->generatedImage[] = $image;
+        $this->assertFileExists($image->getNewFilePath());
+        $this->assertEquals(Image::WEBP_MIME_TYPE, $this->getFileMemeType($image->getNewFilePath()));
     }
 
     /**
      * @param $filePath
+     *
      * @return mixed
      */
     protected function getFileMemeType($filePath)


### PR DESCRIPTION
Apply changes in order to fix review notes:
- Uses fopen to load the image over HTTP. allow_url_fopen required.
- Doesn't use a stream context to provide HTTP timeouts or proxies, follow redirects, etc
- Uses a custom filename randomisation scheme instead of tempnam()
- Reads the entire source image into memory on every request, even if it's located on a blacklisted domain or has already been fetched
- Uses external commands to process images, but does not apply memory limits or timeouts