### PR TITLE
Refactor: Clarified and separated logic for output file extensions, closes #114

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,9 +266,9 @@ The basic options are: `NorthWest`, `North`, `NorthEast`, `West`, `Center`, `Eas
 ### `o` : output
 `string`  
 *Default:* `auto`  
-*Description:* Output format requested, for example you can force the output as jpeg file in case of source file is png. The default `auto` will try to output the same format as the source image or fallback to **jpg**.
+*Description:* Output format requested, for example you can force the output as jpeg file in case of source file is png. The default `auto` will try to output the best format for the requesting browser, falling back to the same format as the source image or finally with a fallback to **jpg**.
 
-**example:`o_auto`,`o_png`,`o_webp`,`o_jpeg`,`o_jpg`** 
+**example:`o_auto`,`o_input`,`o_png`,`o_webp`,`o_jpeg`,`o_jpg`**
 
 ### `q` : quality
 `int` (0-100)  

--- a/docs/url-options.md
+++ b/docs/url-options.md
@@ -109,9 +109,11 @@ The basic options are: `NorthWest`, `North`, `NorthEast`, `West`, `Center`, `Eas
 ### `o` : output
 `string`
 *Default:* `auto`
-*Description:* Output format requested, for example you can force the output as jpeg file in case of source file is png. The default `auto` will try to output the same format as the source image or fallback to **jpg**.
+*Description:* Output format requested, for example you can force the output as jpeg file in case of source file is png. The default `auto` will try to output the best format for the requesting browser, falling back to the same format as the source image or finally with a fallback to **jpg**.
 
-**example:`o_auto`,`o_png`,`o_webp`,`o_jpeg`,`o_jpg`** 
+If `input` is passed, no "optimal" format will be attempted. Flyimg will try to respond with the source format or fallback to `jpg`.
+
+**example:`o_auto`,`o_input`,`o_png`,`o_webp`,`o_jpeg`,`o_jpg`**
 
 
 ### `q` : quality

--- a/src/Core/Entity/OutputImage.php
+++ b/src/Core/Entity/OutputImage.php
@@ -46,7 +46,7 @@ class OutputImage
     protected $commandString;
 
     /** @var array list of the supported output extensions */
-    protected $supportedOutputExtensions = [self::EXT_PNG, self::EXT_JPG, self::EXT_GIF, self::EXT_WEBP];
+    protected $allowedOutExtensions = [self::EXT_PNG, self::EXT_JPG, self::EXT_GIF, self::EXT_WEBP];
 
     /**
      * OutputImage constructor.
@@ -196,7 +196,7 @@ class OutputImage
         } elseif ($requestedOutput == self::EXT_AUTO) {
             $resolvedExtension = $this->getAutoExtension();
         } else {
-            if ( !in_array($requestedOutput, $this->supportedOutputExtensions) ) {
+            if (!in_array($requestedOutput, $this->allowedOutExtensions)) {
                 // Maybe trow exception only when in debug mode ?
                 throw new InvalidArgumentException("Invalid file output requested : ".$requestedOutput);
             }
@@ -215,7 +215,7 @@ class OutputImage
     protected function getAutoExtension(): string
     {
         // for now AUTO means webP, or ...
-        if($this->isWebPBrowserSupported()) {
+        if ($this->isWebPBrowserSupported()) {
             return self::EXT_WEBP;
         }
 

--- a/src/Core/Entity/OutputImage.php
+++ b/src/Core/Entity/OutputImage.php
@@ -8,8 +8,6 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Class OutputImage
  * @package Core\Entity
- *
- * @todo Consider move all the extension / mime-type definitions and checking to a separate class (static?)
  */
 class OutputImage
 {

--- a/src/Core/Handler/ImageHandler.php
+++ b/src/Core/Handler/ImageHandler.php
@@ -119,11 +119,11 @@ class ImageHandler
         $faceCropPosition = $outputImage->extract('face-crop-position');
         $faceBlur = $outputImage->extract('face-blur');
 
-        if ($faceBlur && !$outputImage->isGifSupport()) {
+        if ($faceBlur && !$outputImage->isOutputGif()) {
             $this->faceDetectProcessor->blurFaces($outputImage->getInputImage());
         }
 
-        if ($faceCrop && !$outputImage->isGifSupport()) {
+        if ($faceCrop && !$outputImage->isOutputGif()) {
             $this->faceDetectProcessor->cropFaces($outputImage->getInputImage(), $faceCropPosition);
         }
     }

--- a/src/Core/Processor/ImageProcessor.php
+++ b/src/Core/Processor/ImageProcessor.php
@@ -46,17 +46,17 @@ class ImageProcessor extends Processor
         $command[] = self::IM_CONVERT_COMMAND;
         $tmpFileName = $outputImage->getInputImage()->getSourceImagePath();
 
-        //Check the image is gif
-        if ($outputImage->isGifSupport()) {
+        //Check the source image is gif
+        if ($outputImage->isInputGif()) {
             $command[] = '-coalesce';
             if ($outputImage->getOutputImageExtension() != OutputImage::EXT_GIF) {
                 $tmpFileName .= '['.escapeshellarg($frame).']';
             }
         }
 
-        $command[] = " ".$tmpFileName;
-        $command[] = ' -'.$resizeOperator.' '.
-            $size.$gravity.$extent.
+        $command[] = " " . $tmpFileName;
+        $command[] = ' -' . $resizeOperator . ' ' .
+            $size . $gravity . $extent .
             ' -colorspace sRGB';
 
         foreach ($outputImage->getInputImage()->getOptions() as $key => $value) {
@@ -92,12 +92,12 @@ class ImageProcessor extends Processor
     {
         $quality = $outputImage->extract('quality');
         /** WebP format */
-        if (is_executable(self::CWEBP_COMMAND) && $outputImage->isWebPSupport()) {
+        if (is_executable(self::CWEBP_COMMAND) && $outputImage->isOutputWebP()) {
             $lossLess = $outputImage->extract('webp-lossless') ? 'true' : 'false';
             $command[] = "-quality ".escapeshellarg($quality).
                 " -define webp:lossless=".$lossLess." ".escapeshellarg($outputImage->getOutputImagePath());
         } /** MozJpeg compression */
-        elseif (is_executable(self::MOZJPEG_COMMAND) && $outputImage->isMozJpegSupport()) {
+        elseif (is_executable(self::MOZJPEG_COMMAND) && $outputImage->isOutputMozJpeg()) {
             $command[] = "TGA:- | ".escapeshellarg(self::MOZJPEG_COMMAND)
                 ." -quality ".escapeshellarg($quality)
                 ." -outfile ".escapeshellarg($outputImage->getOutputImagePath())
@@ -157,7 +157,7 @@ class ImageProcessor extends Processor
             $gravity = '';
         }
         //In cas on png format, remove extent option
-        if ($outputImage->isPngSupport()) {
+        if ($outputImage->isOutputPng()) {
             $extent = '';
         }
 


### PR DESCRIPTION
Do we have defined rules regarding whitespace? do we follow some guideline?

Also, can I return early in a method?