### PR TITLE
issue-#197: Remove the Refresh option in the hash generated for output img

### DIFF
--- a/src/Core/Entity/OptionsBag.php
+++ b/src/Core/Entity/OptionsBag.php
@@ -67,7 +67,13 @@ class OptionsBag
         // to ignore extra image parameters
         $parsedImageUrl = preg_replace('/\\?.*/', '', $imageUrl);
 
-        return md5(implode('.', $this->asArray()).$parsedImageUrl);
+        // Remove rf from the generated image
+        $keys = $this->asArray();
+        if (!empty($keys['refresh']) && $keys['refresh'] == 1) {
+            $keys['refresh'] = null;
+        }
+
+        return md5(implode('.', $keys).$parsedImageUrl);
     }
 
     /**


### PR DESCRIPTION
Refresh option should be removed from the hashed string for the generated image #197 closes #197