### PR TITLE
Update the dockerfile to use the latest base image 1.1.0, closes #229

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM flyimg/base-image:1.0.0
+FROM flyimg/base-image:1.1.0
 
 COPY .    /var/www/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,3 @@ RUN usermod -u 1000 www-data && \
 
 RUN composer install --no-dev --optimize-autoloader
 
-EXPOSE 80
-
-CMD /usr/bin/supervisord


### PR DESCRIPTION
Update the dockerfile to use the latest base image 1.1.0, closes #229