### PR TITLE
Add ?git_repo to cloud-run-button

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You pass the image URL and a set of keys with options, like size or compression.
 <!-- https://m0.cl/t/butterfly-3000.jpg -->
 <img src="https://www.myservice.io/upload/w_333,h_333,q_90/https://m0.cl/t/butterfly-3000.jpg">
 ```
-[![Run on Google Cloud](https://storage.googleapis.com/cloudrun/button.svg)](https://deploy.cloud.run)
+[![Run on Google Cloud](https://storage.googleapis.com/cloudrun/button.svg?git_repo=https://github.com/flyimg/flyimg.git)](https://deploy.cloud.run)
 
 # Basic Usage Examples
 ## Get an image to fill exact dimensions


### PR DESCRIPTION
This preserves the source repo information so that it
works from http://flyimg.io/ as well.

re: #231 