### PR TITLE
Feature/pdf support (WIP needs tests)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM flyimg/base-image:1.1.0
 
+# Install other file processors.
+RUN apt-get update
+RUN apt-get install -y ghostscript
+
 COPY .    /var/www/html
 
 #add www-data + mdkdir var folder

--- a/config/parameters.yml
+++ b/config/parameters.yml
@@ -72,7 +72,7 @@ options_keys:
   p1y: extract-top-y
   p2x: extract-bottom-x
   p2y: extract-bottom-y
-  pg: pdf_page
+  pg: page_number
 
 #Default options values
 default_options:
@@ -107,4 +107,4 @@ default_options:
   extract-top-y: null
   extract-bottom-x: null
   extract-bottom-y: null
-  pdf_page: 1
+  page_number: 1

--- a/config/parameters.yml
+++ b/config/parameters.yml
@@ -72,6 +72,7 @@ options_keys:
   p1y: extract-top-y
   p2x: extract-bottom-x
   p2y: extract-bottom-y
+  pg: pdf_page
 
 #Default options values
 default_options:
@@ -106,3 +107,4 @@ default_options:
   extract-top-y: null
   extract-bottom-x: null
   extract-bottom-y: null
+  pdf_page: 1

--- a/src/Core/Entity/Image/OutputImage.php
+++ b/src/Core/Entity/Image/OutputImage.php
@@ -16,6 +16,7 @@ class OutputImage
     const JPEG_MIME_TYPE = 'image/jpeg';
     const PNG_MIME_TYPE = 'image/png';
     const GIF_MIME_TYPE = 'image/gif';
+    const PDF_MIME_TYPE = 'application/pdf';
 
     /** Extension output */
     const EXT_INPUT = 'input';
@@ -196,6 +197,7 @@ class OutputImage
             self::WEBP_MIME_TYPE => self::EXT_WEBP,
             self::JPEG_MIME_TYPE => self::EXT_JPG,
             self::GIF_MIME_TYPE => self::EXT_GIF,
+            self::PDF_MIME_TYPE => self::EXT_JPG,
         ];
 
         return array_key_exists($mimeType, $mimeToExtensions) ? $mimeToExtensions[$mimeType] : self::EXT_JPG;
@@ -255,5 +257,13 @@ class OutputImage
     public function isWebPBrowserSupported(): bool
     {
         return in_array(self::WEBP_MIME_TYPE, Request::createFromGlobals()->getAcceptableContentTypes());
+    }
+
+    /**
+     * @return bool
+     */
+    public function isInputPdf(): bool
+    {
+        return $this->inputImage->sourceImageMimeType() == self::PDF_MIME_TYPE;
     }
 }

--- a/src/Core/Entity/Image/OutputImage.php
+++ b/src/Core/Entity/Image/OutputImage.php
@@ -60,6 +60,9 @@ class OutputImage
         $this->generateFilesName();
         $this->outputImageExtension = $this->generateFileExtension();
         $this->outputImagePath .= '.'.$this->outputImageExtension;
+        if ($this->isInputPdf()) {
+            $this->outputImageName .= '-' . $this->getPageNumber();
+        }
         $this->outputImageName .= '.'.$this->outputImageExtension;
     }
 
@@ -265,5 +268,16 @@ class OutputImage
     public function isInputPdf(): bool
     {
         return $this->inputImage->sourceImageMimeType() == self::PDF_MIME_TYPE;
+    }
+
+    /**
+     * Get page number
+     *
+     * @return integer
+     */
+    public function getPageNumber(): int
+    {
+        $opts = $this->inputImage->optionsBag();
+        return $opts->get('page_number');
     }
 }

--- a/src/Core/Processor/ImageProcessor.php
+++ b/src/Core/Processor/ImageProcessor.php
@@ -71,7 +71,10 @@ class ImageProcessor extends Processor
             $command->addArgument('-coalesce');
         }
 
-        $command->addArgument($this->getSourceImagePath($outputImage));
+        $pdfPageNo = $outputImage->isInputPdf() ? '[' . ($outputImage->extractKey('pdf_page') - 1) . ']' : '';
+
+        $command->addArgument($this->getSourceImagePath($outputImage) . $pdfPageNo) ;
+
         $command->addArgument($this->calculateSize());
         $command->addArgument('-colorspace', 'sRGB');
 

--- a/src/Core/Processor/ImageProcessor.php
+++ b/src/Core/Processor/ImageProcessor.php
@@ -71,7 +71,7 @@ class ImageProcessor extends Processor
             $command->addArgument('-coalesce');
         }
 
-        $pdfPageNo = $outputImage->isInputPdf() ? '[' . ($outputImage->extractKey('pdf_page') - 1) . ']' : '';
+        $pdfPageNo = $outputImage->isInputPdf() ? '[' . ($outputImage->extractKey('page_number') - 1) . ']' : '';
 
         $command->addArgument($this->getSourceImagePath($outputImage) . $pdfPageNo) ;
 

--- a/tests/Core/Entity/Image/OutputImageTest.php
+++ b/tests/Core/Entity/Image/OutputImageTest.php
@@ -53,6 +53,7 @@ class OutputImageTest extends BaseTest
             'extract-top-y' => null,
             'extract-bottom-x' => null,
             'extract-bottom-y' => null,
+            'page_number' => 1,
         ];
         $optionsBag = new OptionsBag($this->imageHandler->appParameters(), self::OPTION_URL);
         $inputImage = new InputImage($optionsBag, self::JPG_TEST_IMAGE);


### PR DESCRIPTION
RE issue #241

OK, I have the pdf version working.

This generates an image for page 1. (no page specified).
`http://127.0.0.1:8080/upload/w_1024,h_1024,q_75/https://example.com/seasons.pdf`

Adding `pg_[n]` generates a specific page. E.g. this would generate page 3.
`http://127.0.0.1:8080/upload/w_1024,h_1024,q_75,pg_3/https://example.com/seasons.pdf`

When the cached image is generated I'm appending '-1', '-2', '-3' etc to it depending on the page requested. No page specified defaults to appending '-1'.

I just need some advice on where/how best to set up the tests for it.

I haven't committed a PDF to test because I don't know if you have a preferred one.
