### PR TITLE
Fixes error when accessing URL with whitespace

### DIFF
--- a/src/Core/Entity/Image/InputImage.php
+++ b/src/Core/Entity/Image/InputImage.php
@@ -88,8 +88,11 @@ class InputImage
                 ],
         ];
         $context = stream_context_create($opts);
-
-        if (!$stream = @fopen($this->sourceImageUrl, 'r', false, $context)
+        
+        $parts = pathinfo($this->sourceImageUrl);
+        $sourceUrl = $parts['dirname'] . '/' . rawurlencode($parts['basename]);
+        
+        if (!$stream = @fopen($sourceUrl, 'r', false, $context)
         ) {
             throw  new ReadFileException(
                 'Error occurred while trying to read the file Url : '


### PR DESCRIPTION
When trying to convert/resize files with whitespace on the name, there was always an error "Error occurred while trying to read the file". This PR solves it