### PR TITLE
fix waiting-for-a-runner-to-pick-up-this-job issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     # Name the Job
     name: Lint code base
     # Set the type of machine to run on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
-      # Checks out a copy of your repository on the ubuntu-18.04 machine
+      # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
         uses: actions/checkout@v2
 
@@ -30,7 +30,7 @@ jobs:
           VALIDATE_DOCKERFILE_HADOLINT: false
 
   build-test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Run Unit Tests
 
     steps:


### PR DESCRIPTION
One potential reason might be that GitHub does not support anymore the operating system requested.