### PR TITLE
Add parameter to forward request header to source image server

### DIFF
--- a/config/parameters.yml
+++ b/config/parameters.yml
@@ -39,6 +39,9 @@ thread: 1
 #Extra options for the header sent to source image server, as some servers requires the User-Agent.
 header_extra_options: 'User-Agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/20110201'
 
+#List of request header to forward to source image server (example Authorization)
+forward_request_headers: []
+
 #Keys used in url to match options. Ex: q_80,w_200,h_100
 options_keys:
   moz: mozjpeg

--- a/src/Core/Entity/Image/InputImage.php
+++ b/src/Core/Entity/Image/InputImage.php
@@ -6,6 +6,7 @@ use Core\Entity\OptionsBag;
 use Core\Exception\ReadFileException;
 use Core\Entity\ImageMetaInfo;
 use Core\Processor\VideoProcessor;
+use Symfony\Component\HttpFoundation\Request;
 
 class InputImage
 {
@@ -75,14 +76,30 @@ class InputImage
      */
     protected function saveToTemporaryFile()
     {
-        if (file_exists($this->sourceImagePath) && !$this->optionsBag->get('refresh')) {
+        $header = $this->optionsBag->appParameters()->parameterByKey('header_extra_options');
+        $refresh = $this->optionsBag->get('refresh');
+        $forwardRequestHeaders = (array) $this->optionsBag->appParameters()->parameterByKey('forward_request_headers', []);
+        if (!empty($forwardRequestHeaders)) {
+            $requestHeaders = Request::createFromGlobals()->headers;
+            foreach ($forwardRequestHeaders as $name) {
+                if ($requestHeaders->has($name)) {
+                    $value = $requestHeaders->get($name);
+                    $header .= "\r\n$name: $value";
+                    if ('Authorization' === $name) {
+                        $this->sourceImagePath .= md5($value);
+                    }
+                }
+            }
+        }
+
+        if (file_exists($this->sourceImagePath) && !$refresh) {
             return;
         }
 
         $opts = [
             'http' =>
             [
-                'header' => $this->optionsBag->appParameters()->parameterByKey('header_extra_options'),
+                'header' => $header,
                 'method' => 'GET',
                 'max_redirects' => '5',
             ],

--- a/src/Core/Entity/Image/InputImage.php
+++ b/src/Core/Entity/Image/InputImage.php
@@ -78,7 +78,9 @@ class InputImage
     {
         $header = $this->optionsBag->appParameters()->parameterByKey('header_extra_options');
         $refresh = $this->optionsBag->get('refresh');
-        $forwardRequestHeaders = (array) $this->optionsBag->appParameters()->parameterByKey('forward_request_headers', []);
+        $forwardRequestHeaders = (array) $this->optionsBag
+            ->appParameters()
+            ->parameterByKey('forward_request_headers', []);
         if (!empty($forwardRequestHeaders)) {
             $requestHeaders = Request::createFromGlobals()->headers;
             foreach ($forwardRequestHeaders as $name) {


### PR DESCRIPTION
Introduces a parameter to configure a list of headers to forward to the image server.

Resolve issue https://github.com/flyimg/flyimg/issues/357

Security note: 
if the list includes the Authorization header the path of the temporary file is modified with the hash of the value