### PR TITLE
fix: add disable cache option

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           host: ${{ secrets.FLYIMG_DEMO_HOST }}
           username: ${{ secrets.FLYIMG_DEMO_USERNAME }}
+          port: ${{ secrets.FLYIMG_DEMO_PORT }}
           key: ${{ secrets.FLYIMG_DEMO_KEY }}
           script: |
             bash -c "docker rm -f flyimg &>/dev/null"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,14 @@
 ---
 name: CI
 
-# Run this workflow every time a new commit pushed to your repository
-on: [push, pull_request]
+# Run this workflow every time a new commit pushed to main branch or on pull request to main
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   # Set the job key. The key is displayed as the job name

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /build/
 /xdebug/
 /web/uploads
+.phpunit.cache/
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/config/parameters.yml
+++ b/config/parameters.yml
@@ -37,6 +37,9 @@ aws_s3:
 # Number of threads for Imagemagick to use
 thread: 1
 
+# when set to true the generated image will be deleted from the cache in web/upload and served directly in the response
+disable_cache: false
+
 #Extra options for the header sent to source image server, as some servers requires the User-Agent.
 header_extra_options: 'User-Agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/20110201'
 

--- a/config/parameters.yml
+++ b/config/parameters.yml
@@ -1,6 +1,4 @@
 ---
-application_name: Flyimg.io
-
 #debug
 debug: true
 

--- a/docs/application-options.md
+++ b/docs/application-options.md
@@ -4,11 +4,6 @@
 
 Here are the app options you can configure with the [config/parameters.yml](https://github.com/flyimg/flyimg/blob/main/config/parameters.yml) these options operate at runtime, you don't need to rebuild the container or restart any service, all requests<sup><a name="footnote1">1</a></sup> will check this config.
 
-### application_name
-
-_Defaults to:_ `Flyimg.io`
-_Description:_ Seems to do nothing, I propose to delete it.
-
 ### debug
 
 _Defaults to:_ `true`
@@ -44,6 +39,12 @@ _Defaults to:_
 ```
 
 _Description:_ If `restricted_domains` is enabled, put your whitelisted domains in this list, subdomains are also OK. For the [Digital Ocean Provisioning Script](https://github.com/flyimg/DigitalOcean-provision) you can set the restricted domains at the droplet provisioning step.
+
+### disable_cache
+
+_Defaults to:_ `false`
+_Description:_ When set to true the generated image will be deleted from the cache in web/upload and served directly in the response
+
 
 ### storage_system
 

--- a/src/Core/Controller/CoreController.php
+++ b/src/Core/Controller/CoreController.php
@@ -18,7 +18,7 @@ class CoreController
         $this->response = new Response(
             $this->app['image.handler'],
             $this->app['flysystems'],
-            $this->app['params']->parameterByKey('header_cache_days')
+            $this->app['params']
         );
     }
 

--- a/src/Core/Entity/Image/OutputImage.php
+++ b/src/Core/Entity/Image/OutputImage.php
@@ -164,13 +164,24 @@ class OutputImage
     }
 
     /**
+     * Remove Generated Image
+     */
+    public function removeGeneratedImage()
+    {
+        $generatedImage = sprintf("%s%s", UPLOAD_DIR, $this->getOutputImageName());
+        if (file_exists($generatedImage)) {
+            unlink($generatedImage);
+        }
+    }
+
+    /**
      * Generate files name + files path
      */
     protected function generateFilesName()
     {
         $hashedOptions = $this->inputImage->optionsBag();
         $this->outputImageName = $hashedOptions->hashedOptionsAsString($this->inputImage->sourceImageUrl());
-        $this->outputImagePath = TMP_DIR . $this->outputImageName;
+        $this->outputImagePath = sprintf("%s%s", TMP_DIR, $this->outputImageName);
 
         if ($hashedOptions->get('refresh')) {
             $this->outputImagePath .= uniqid("-", true);
@@ -202,7 +213,7 @@ class OutputImage
     /**
      * given a mime-type this returns the extension associated to it
      *
-     * @param  string $mimeType mime-type
+     * @param string $mimeType mime-type
      *
      * @return string extension OR jpeg as default
      */

--- a/tests/Core/BaseTest.php
+++ b/tests/Core/BaseTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Core;
 
 use Core\Entity\Image\OutputImage;
+use Core\Entity\Response;
 use Core\Handler\ImageHandler;
 use PHPUnit\Framework\TestCase;
 use Silex\Application;
@@ -44,6 +45,11 @@ class BaseTest extends TestCase
     protected $imageHandler = null;
 
     /**
+     * @var Response
+     */
+    protected $response = null;
+
+    /**
      * @var array
      */
     protected $generatedImage = [];
@@ -55,6 +61,11 @@ class BaseTest extends TestCase
     {
         $this->app = $this->createApplication();
         $this->imageHandler = $this->app['image.handler'];
+        $this->response = new Response(
+            $this->app['image.handler'],
+            $this->app['flysystems'],
+            $this->app['params']
+        );
     }
 
     /**

--- a/tests/Core/Controller/CoreControllerTest.php
+++ b/tests/Core/Controller/CoreControllerTest.php
@@ -35,7 +35,7 @@ class CoreControllerTest extends BaseTest
     {
         $this->expectException(FileNotFoundException::class);
         $coreController = new CoreController($this->app);
-        $coreController->render('notExitfile');
+        $coreController->render('notExistFile');
     }
 
     /**

--- a/tests/Core/Entity/ResponseTest.php
+++ b/tests/Core/Entity/ResponseTest.php
@@ -10,7 +10,7 @@ class ResponseTest extends BaseTest
      * @return void
      * @throws \Exception
      */
-    public function testEnableCacheAndGenerateImage():void
+    public function testEnableCacheAndGenerateImage(): void
     {
         $this->app['params']->addParameter('disable_cache', false);
         $image = $this->imageHandler->processImage('w_10,h_10,rf_1', parent::PNG_TEST_IMAGE);
@@ -22,7 +22,7 @@ class ResponseTest extends BaseTest
      * @return void
      * @throws \Exception
      */
-    public function testDisableCacheAndGenerateImage():void
+    public function testDisableCacheAndGenerateImage(): void
     {
         $this->app['params']->addParameter('disable_cache', true);
         $image = $this->imageHandler->processImage('w_100,h_250,rf_1', parent::JPG_TEST_IMAGE);

--- a/tests/Core/Entity/ResponseTest.php
+++ b/tests/Core/Entity/ResponseTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Core\Entity;
+
+use Tests\Core\BaseTest;
+
+class ResponseTest extends BaseTest
+{
+    /**
+     * @return void
+     * @throws \Exception
+     */
+    public function testEnableCacheAndGenerateImage():void
+    {
+        $this->app['params']->addParameter('disable_cache', false);
+        $image = $this->imageHandler->processImage('w_10,h_10,rf_1', parent::PNG_TEST_IMAGE);
+        $this->generatedImage[] = $image;
+        $this->assertFileExists(UPLOAD_DIR . $image->getOutputImageName());
+    }
+
+    /**
+     * @return void
+     * @throws \Exception
+     */
+    public function testDisableCacheAndGenerateImage():void
+    {
+        $this->app['params']->addParameter('disable_cache', true);
+        $image = $this->imageHandler->processImage('w_100,h_250,rf_1', parent::JPG_TEST_IMAGE);
+        $this->response->generateImageResponse($image);
+        $this->assertFileDoesNotExist(UPLOAD_DIR . $image->getOutputImageName());
+    }
+}


### PR DESCRIPTION
Add an option to disable generated images that are being used as cache.
Add unit tests to cover the newly added option.
This should close #375 