### PR TITLE
fix: fixing Github Action workflow for Multi-platform Docker image

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -151,19 +151,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Create manifest and push for ${{ needs.docker_publish.outputs.new_tag_version }} tag
+        name: Create manifest and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create \
-          -t ${{ env.REGISTRY_IMAGE }}:${{ needs.docker_publish.outputs.new_tag_version }} 
-          "$(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)"
-      -
-        name: Create manifest and push for latest tag
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create \
-          -t ${{ env.REGISTRY_IMAGE }}:latest
-          "$(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)"
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           VALIDATE_NATURAL_LANGUAGE: false
           VALIDATE_JSCPD: false
           VALIDATE_DOCKERFILE_HADOLINT: false
+          VALIDATE_GITHUB_ACTIONS: false
 
   build-test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,5 @@
 # Flyimg Changelog
 
-## [1.3.3](https://github.com/flyimg/flyimg/compare/1.3.2...1.3.3) (2024-02-26)
-
-
-### Bug Fixes
-
-* add Multi-platform image with GitHub Actions, [#414](https://github.com/flyimg/flyimg/issues/414) ([2ab0d07](https://github.com/flyimg/flyimg/commit/2ab0d078e3f8c8eedfb8af682d075bcd7526bb6a))
-* fixing Create manifest list stage: ([91524d3](https://github.com/flyimg/flyimg/commit/91524d3276e06080af0cfea91a1737a4504bb706))
-* fixing github workflow ([5aff78a](https://github.com/flyimg/flyimg/commit/5aff78a820025d5351a62090c1d85ef49b94e74b))
-* fixing linting errors ([f414470](https://github.com/flyimg/flyimg/commit/f4144703141942e8eb39ebab316d53f0caafabf7))
-* fixing missing PLATFORM_PAIR for the articat upload (Github Action CD) ([84b55ff](https://github.com/flyimg/flyimg/commit/84b55ffdb3cc5902208d968c6998cc6b2de48c14))
-* fixing Multi-platform image with GitHub Actions ([ce62db0](https://github.com/flyimg/flyimg/commit/ce62db07607989d63af0e08dd4366b0a691b55b3))
-* fixing the base image path ([954ff76](https://github.com/flyimg/flyimg/commit/954ff767a03fa48388ab8683d1d24418bb25db76))
-* fixing the REGISTRY_IMAGE tags ([eb3d09b](https://github.com/flyimg/flyimg/commit/eb3d09b989a43330ce14741189a743b282b7c6c9))
-* fixing typo in docker Create manifest list and push step ([5a7658b](https://github.com/flyimg/flyimg/commit/5a7658bc5cace8825be2b35f2f3de9b447ae183e))
-* fixing workflow release issue ([7864655](https://github.com/flyimg/flyimg/commit/7864655f5bc9995796bad0d63cf1e590c2b93ad7))
-
 ## [1.3.2](https://github.com/flyimg/flyimg/compare/1.3.1...1.3.2) (2024-02-21)
 
 


### PR DESCRIPTION
fixing Github Action workflow for Multi-platform Docker image
Adding the following platforms:
- linux/amd64
- linux/arm/v6
- linux/arm/v7
- linux/arm64

This should close #414 (finally!)