### PR TITLE
fix: update flyimg base version to support multi arch build, fixing #414

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM flyimg/base-image:1.4.1
+FROM flyimg/base-image:1.5.0
 
 COPY .    /var/www/html
 


### PR DESCRIPTION
fix: update flyimg base version to support multi-arch build, fixing #414
unfortunately pillow-avif-plugin is not installable on arm arch, therefore face-detection will fail on arm machines.