### PR TITLE
fix: Fix cronjob to cleanup the tmp folder and JetBrains log, closes #502

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ See the [ADOPTERS.md](ADOPTERS.md) file for a list of companies / organisations 
 
 A special thanks to JetBrains for supporting our project with their [open source license program](https://www.jetbrains.com/buy/opensource/).
 
-![Jetbrains](https://demo.flyimg.io/upload/w_150/https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.png)
+![Jetbrains](https://demo.flyimg.io/upload/w_200/https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.png)
 
 ## Contributors
 

--- a/cleanup-tmp.sh
+++ b/cleanup-tmp.sh
@@ -23,10 +23,10 @@ if [ "$ENABLE_CLEANUP" == "false" ]; then
   exit 0
 fi
 
-# Exiting when $TMP_DIR does not exist
+# Create directory $TMP_DIR if it doesn't exist
 if [ ! -d "$TMP_DIR" ]; then
-  echo "Directory $TMP_DIR does not exist. Exiting."
-  exit 0
+  echo "Directory $TMP_DIR does not exist. creating..."
+  mkdir -p "$TMP_DIR"
 fi
 
 CRON_INTERVAL=$(grep -E '^cronjob_cleanup_interval:' "$YAML_FILE" | cut -d' ' -f2- | tr -d '"')


### PR DESCRIPTION
fix: Fix cronjob to cleanup the tmp folder and JetBrains logo, closes #502 