### PR TITLE
fix: fix Same image content returned for different image URLs when loading within short timeframe

### DIFF
--- a/src/Core/Entity/Image/InputImage.php
+++ b/src/Core/Entity/Image/InputImage.php
@@ -49,7 +49,7 @@ class InputImage
         $this->optionsBag = $optionsBag;
         $this->sourceImageUrl = $sourceImageUrl;
 
-        $this->sourceImagePath = $optionsBag->hashOriginalImageUrl($this->sourceImageUrl);
+        $this->sourceImagePath =  TMP_DIR . 'original-' . md5($this->sourceImageUrl);
         $this->saveToTemporaryFile();
 
         $this->sourceImageInfo = new ImageMetaInfo($this->sourceImagePath);

--- a/src/Core/Entity/OptionsBag.php
+++ b/src/Core/Entity/OptionsBag.php
@@ -63,30 +63,13 @@ class OptionsBag
      */
     public function hashedOptionsAsString(string $imageUrl): string
     {
-        // to ignore extra image parameters
-        $parsedImageUrl = preg_replace('/\\?.*/', '', $imageUrl);
-
         // Remove rf from the generated image
         $keys = $this->asArray();
         if (!empty($keys['refresh']) && $keys['refresh'] == 1) {
             $keys['refresh'] = null;
         }
 
-        return md5(implode('.', $keys) . $parsedImageUrl);
-    }
-
-    /**
-     * Return a hashed string based on original image URL
-     *
-     * @param string $imageUrl
-     *
-     * @return string
-     */
-    public function hashOriginalImageUrl(string $imageUrl): string
-    {
-        $parsedImageUrl = preg_replace('/\\?.*/', '', $imageUrl);
-
-        return TMP_DIR . 'original-' . md5($parsedImageUrl);
+        return md5(implode('.', $keys) . $imageUrl);
     }
 
     /**

--- a/tests/Core/BaseTest.php
+++ b/tests/Core/BaseTest.php
@@ -29,7 +29,10 @@ class BaseTest extends TestCase
     public const EXTRACT_TEST_IMAGE_RESULT = __DIR__ . '/../testImages/extract-result.jpg';
 
     public const SMART_CROP_TEST_IMAGE = __DIR__ . '/../testImages/smart_crop.jpg';
-    public const EMART_CROP_TEST_IMAGE_RESULT = __DIR__ . '/../testImages/smart_crop_restult.jpg';
+    public const SMART_CROP_TEST_IMAGE_RESULT = __DIR__ . '/../testImages/smart_crop_restult.jpg';
+
+    public const REMOTE_IMAGE_WITH_ARGS_1 = 'https://images.citybreakcdn.com/image.aspx?ImageId=8175306';
+    public const REMOTE_IMAGE_WITH_ARGS_2 = 'https://images.citybreakcdn.com/image.aspx?ImageId=7697905';
 
     public const OPTION_URL = 'w_200,h_100,c_1,bg_#999999,rz_1,sc_50,r_-45,unsh_0.25x0.25+8+0.065,ett_100x80,fb_1,rf_1';
     public const CROP_OPTION_URL = 'w_200,h_100,c_1,rf_1';

--- a/tests/Core/Entity/ResponseTest.php
+++ b/tests/Core/Entity/ResponseTest.php
@@ -39,6 +39,9 @@ class ResponseTest extends BaseTest
         $image2 = $this->imageHandler->processImage('w_100,h_250,rf_1', parent::REMOTE_IMAGE_WITH_ARGS_2);
         $this->response->generateImageResponse($image1);
         $this->response->generateImageResponse($image2);
-        $this->assertNotEquals($this->app['flysystems']['storage_handler']->checksum($image1->getOutputImageName()), $this->app['flysystems']['storage_handler']->checksum($image2->getOutputImageName()));
+        $this->assertNotEquals(
+            $this->app['flysystems']['storage_handler']->checksum($image1->getOutputImageName()), 
+            $this->app['flysystems']['storage_handler']->checksum($image2->getOutputImageName())
+        );
     }
 }

--- a/tests/Core/Entity/ResponseTest.php
+++ b/tests/Core/Entity/ResponseTest.php
@@ -29,4 +29,16 @@ class ResponseTest extends BaseTest
         $this->response->generateImageResponse($image);
         $this->assertFalse($this->app['flysystems']['storage_handler']->has($image->getOutputImageName()));
     }
+
+    /**
+     * @return void
+     */
+    public function testImageSameUrlDifferentArgs(): void
+    {
+        $image1 = $this->imageHandler->processImage('w_100,h_250,rf_1', parent::REMOTE_IMAGE_WITH_ARGS_1);
+        $image2 = $this->imageHandler->processImage('w_100,h_250,rf_1', parent::REMOTE_IMAGE_WITH_ARGS_2);
+        $this->response->generateImageResponse($image1);
+        $this->response->generateImageResponse($image2);
+        $this->assertNotEquals($this->app['flysystems']['storage_handler']->checksum($image1->getOutputImageName()), $this->app['flysystems']['storage_handler']->checksum($image2->getOutputImageName()));
+    }
 }

--- a/tests/Core/Entity/ResponseTest.php
+++ b/tests/Core/Entity/ResponseTest.php
@@ -40,7 +40,7 @@ class ResponseTest extends BaseTest
         $this->response->generateImageResponse($image1);
         $this->response->generateImageResponse($image2);
         $this->assertNotEquals(
-            $this->app['flysystems']['storage_handler']->checksum($image1->getOutputImageName()), 
+            $this->app['flysystems']['storage_handler']->checksum($image1->getOutputImageName()),
             $this->app['flysystems']['storage_handler']->checksum($image2->getOutputImageName())
         );
     }

--- a/tests/Core/Processor/SmartCropProcessorTest.php
+++ b/tests/Core/Processor/SmartCropProcessorTest.php
@@ -17,7 +17,7 @@ class SmartCropProcessorTest extends BaseTest
     {
         $image = $this->imageHandler->processImage('smc_1,rf_1,o_jpg', parent::SMART_CROP_TEST_IMAGE);
         $filesize = filesize($image->getOutputTmpPath());
-        $filesize2 = filesize(parent::EMART_CROP_TEST_IMAGE_RESULT);
+        $filesize2 = filesize(parent::SMART_CROP_TEST_IMAGE_RESULT);
         $this->generatedImage[] = $image;
         $this->assertFileExists($image->getOutputTmpPath());
         $this->assertEquals($filesize, $filesize2);


### PR DESCRIPTION
Fix Same image content returned for different image URLs when loading within a short timeframe
Add 1 unit test to cover this scenario.
closes #522 
