### PR TITLE
feat: add support for POST uploads and S3 sources

### DIFF
--- a/config/routes.yml
+++ b/config/routes.yml
@@ -9,6 +9,12 @@ upload:
                imageSrc: ''}
    requirements:
       imageSrc: .*
+   methods: [GET]
+
+upload_post:
+   path: /upload/{options}
+   defaults: {_controller: 'Core\Controller\DefaultController::uploadStreamAction'}
+   methods: [POST]
 
 path:
    path: /path/{options}/{imageSrc}
@@ -16,3 +22,4 @@ path:
                imageSrc: ''}
    requirements:
       imageSrc: .*
+   methods: [GET]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,3 +106,50 @@ _Defaults to:_ `local`
 
 More info at [Storage Options](storage-options.md).
 
+
+### aws_s3
+
+When using S3 sources (e.g., `s3://bucket/key`), configure the S3 parameters in `config/parameters.yml` under `aws_s3`:
+
+```yml
+aws_s3:
+  access_id: "..."
+  secret_key: "..."
+  region: "eu-central-1"
+  bucket_name: "my-bucket"
+  # path_prefix: ''
+  # visibility: 'PRIVATE'   # PUBLIC or PRIVATE
+  # endpoint: 'https://%s.s3.%s.amazonaws.com/'
+  # bucket_endpoint: false
+  # use_path_style_endpoint: false
+```
+
+- `endpoint` can target third-party S3-compatible services. It should accept `%s` placeholders for bucket and region.
+- For private objects, you may need to forward request headers (e.g., `Authorization`).
+
+### forward_request_headers
+
+List of request headers that Flyimg will forward when fetching the source image. Useful when the upstream requires authentication.
+
+```yml
+forward_request_headers:
+  - Authorization
+```
+
+### header_extra_options
+
+Additional HTTP headers sent when fetching source images (useful for custom User-Agent, etc.).
+
+```yml
+header_extra_options:
+  - 'User-Agent: Mozilla/5.0 (... your UA ... )'
+```
+
+### POST upload endpoint
+
+Flyimg supports uploading images via POST to avoid long URLs:
+
+- Endpoint: `POST /upload/{image_options}`
+- Bodies: raw binary (`application/octet-stream` or `image/*`) or JSON `{"base64":"..."}` / `{"dataUri":"data:..."}`
+
+See examples in [URL Options](url-options.md#alternative-sources-and-post-uploads).

--- a/docs/url-options.md
+++ b/docs/url-options.md
@@ -34,6 +34,54 @@ It's the first operation the server does, it will try to get an image from the U
 
 ---
 
+## Alternative sources and POST uploads
+
+In addition to fetching images from an HTTP/HTTPS URL, Flyimg supports:
+
+- data URIs: `data:<mime>;base64,<payload>`
+- S3 references: `s3://<bucket>/<key>`
+- Direct POST uploads with the request body
+
+### POST uploads (recommended for large inputs)
+
+- Endpoint: `POST /upload/{image_options}`
+- Supported bodies:
+  - `application/octet-stream` or any `image/*`: raw binary body
+  - `application/json`: `{ "base64": "<BASE64>" }` or `{ "dataUri": "data:<mime>;base64,<data>" }`
+
+Examples:
+
+```bash
+curl -X POST -H "Content-Type: application/octet-stream" \
+  --data-binary @tests/testImages/square.png \
+  http://localhost:8080/upload/w_300,o_jpg -o out.jpg
+```
+
+```bash
+B64=$(base64 -i tests/testImages/square.jpg)
+curl -X POST -H "Content-Type: application/json" \
+  -d "{\"base64\":\"$B64\"}" \
+  http://localhost:8080/upload/w_300,o_png -o out.png
+```
+
+### GET with data URI
+
+For small payloads only (URLs have size limits):
+
+```
+/upload/w_200,o_jpg/data:image/png;base64,<BASE64>
+```
+
+### S3 sources
+
+Fetch from S3 using a simple URI:
+
+```
+/upload/w_300/s3://my-bucket/path/to/image.png
+```
+
+Configuration for S3 endpoint/region is required; see configuration docs below.
+
 ## image_options
 
 Here you set all the transformations and output settings you want to apply to the image you are fetching.

--- a/src/Core/Controller/DefaultController.php
+++ b/src/Core/Controller/DefaultController.php
@@ -1,12 +1,34 @@
 <?php
+/**
+ * DefaultController
+ *
+ * Handles homepage rendering and image upload/path endpoints.
+ *
+ * @category Controller
+ * @package  Flyimg\\Core\\Controller
+ * @author   Flyimg Team <dev@flyimg.io>
+ * @license  MIT License <https://opensource.org/licenses/MIT>
+ * @link     https://github.com/flyimg/flyimg
+ */
 
 namespace Core\Controller;
 
 use Core\Entity\Response;
 
+/**
+ * Class DefaultController
+ *
+ * @category Controller
+ * @package  Flyimg\\Core\\Controller
+ * @author   Flyimg Team <dev@flyimg.io>
+ * @license  MIT License <https://opensource.org/licenses/MIT>
+ * @link     https://github.com/flyimg/flyimg
+ */
 class DefaultController extends CoreController
 {
     /**
+     * Render the index page (or empty body when demo disabled).
+     *
      * @return string
      */
     public function indexAction()
@@ -22,10 +44,13 @@ class DefaultController extends CoreController
     }
 
     /**
-     * @param string $options
-     * @param string $imageSrc
+     * Process an image from a URL-like source and return the generated image.
+     *
+     * @param string $options  Image transformation options.
+     * @param string $imageSrc Source image spec (URL, data URI, local path, s3 URI).
      *
      * @return Response
+     *
      * @throws \Exception
      */
     public function uploadAction(string $options, ?string $imageSrc = null): Response
@@ -38,10 +63,51 @@ class DefaultController extends CoreController
     }
 
     /**
-     * @param string $options
-     * @param string $imageSrc
+     * Accept binary or base64 payload in request body and process with options.
+     *
+     * @param string $options  Image transformation options.
      *
      * @return Response
+     *
+     * @throws \Exception
+     */
+    public function uploadStreamAction(string $options): Response
+    {
+        $request = $this->app['request_stack']->getCurrentRequest();
+
+        $contentType = $request ? $request->headers->get('Content-Type', '') : '';
+        $rawBody = $request ? $request->getContent() : '';
+
+        // Determine source URL placeholder
+        if (stripos($contentType, 'application/json') !== false) {
+            $data = json_decode($rawBody, true);
+            $source = isset($data['dataUri']) ? (string)$data['dataUri'] : '';
+            if (!$source && isset($data['base64'])) {
+                $source = 'data:application/octet-stream;base64,' . $data['base64'];
+            }
+        } elseif (stripos($contentType, 'application/octet-stream') !== false || stripos($contentType, 'image/') !== false) {
+            $source = 'data:application/octet-stream;base64,' . base64_encode($rawBody);
+        } else {
+            // Fallback: try to treat body as a data URI or base64 string directly
+            $trimmed = trim($rawBody);
+            $source = (stripos($trimmed, 'data:') === 0) ? $trimmed : 'data:application/octet-stream;base64,' . $trimmed;
+        }
+
+        $image = $this->imageHandler()->processImage($options, $source);
+
+        $this->response->generateImageResponse($image);
+
+        return $this->response;
+    }
+
+    /**
+     * Generate output file path for a transformed image.
+     *
+     * @param string $options  Image transformation options.
+     * @param string $imageSrc Source image spec (URL, data URI, local path, s3 URI).
+     *
+     * @return Response
+     *
      * @throws \Exception
      */
     public function pathAction(string $options, ?string $imageSrc = null): Response

--- a/tests/Core/Controller/DefaultControllerTest.php
+++ b/tests/Core/Controller/DefaultControllerTest.php
@@ -1,27 +1,43 @@
 <?php
+/**
+ * DefaultControllerTest
+ *
+ * Functional tests for upload and path endpoints, including POST uploads,
+ * data URIs, and s3 sources.
+ *
+ * @category Tests
+ * @package  Flyimg\\Tests
+ * @author   Flyimg Team <dev@flyimg.io>
+ * @license  MIT License <https://opensource.org/licenses/MIT>
+ * @link     https://github.com/flyimg/flyimg
+ */
 
 namespace Tests\Core\Controller;
 
 use Core\Exception\ExecFailedException;
 use Core\Exception\InvalidArgumentException;
+use Core\Exception\AppException;
 use Core\Exception\ReadFileException;
 use Silex\WebTestCase;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Tests\Core\BaseTest;
 
+/**
+ * Class DefaultControllerTest
+ *
+ * @category Tests
+ * @package  Flyimg\\Tests
+ * @author   Flyimg Team <dev@flyimg.io>
+ * @license  MIT License <https://opensource.org/licenses/MIT>
+ * @link     https://github.com/flyimg/flyimg
+ */
 class DefaultControllerTest extends BaseTest
 {
-    /**
-     *
-     */
     protected function tearDown(): void
     {
         unset($this->app);
     }
 
-    /**
-     *
-     */
     public function testIndexAction()
     {
         $client = static::createClient();
@@ -29,9 +45,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertTrue($client->getResponse()->isOk());
     }
 
-    /**
-     *
-     */
     public function testIndexActionWithDemoDisabled()
     {
         $this->app['params']->addParameter('demo_page_enabled', false);
@@ -41,9 +54,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertEmpty($client->getResponse()->getContent());
     }
 
-    /**
-     *
-     */
     public function testUploadAction()
     {
         $client = static::createClient();
@@ -52,9 +62,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertFalse($client->getResponse()->isEmpty());
     }
 
-    /**
-     * @return void
-     */
     public function testUploadActionWebp()
     {
         $client = static::createClient();
@@ -63,9 +70,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertFalse($client->getResponse()->isEmpty());
     }
 
-    /**
-     * @return void
-     */
     public function testUploadActionAvif()
     {
         $client = static::createClient();
@@ -74,9 +78,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertFalse($client->getResponse()->isEmpty());
     }
 
-    /**
-     *
-     */
     public function testUploadActionGif()
     {
         $client = static::createClient();
@@ -85,9 +86,60 @@ class DefaultControllerTest extends BaseTest
         $this->assertFalse($client->getResponse()->isEmpty());
     }
 
-    /**
-     *
-     */
+    /** Ensure POST /upload with octet-stream body works. */
+    public function testUploadPostOctetStream()
+    {
+        $client = static::createClient();
+        $binary = file_get_contents(BaseTest::PNG_TEST_IMAGE);
+        $client->request(
+            'POST',
+            '/upload/w_50,o_jpg',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/octet-stream'],
+            $binary
+        );
+        $this->assertTrue($client->getResponse()->isOk());
+        $this->assertFalse($client->getResponse()->isEmpty());
+    }
+
+    /** Ensure POST /upload with JSON {base64} works. */
+    public function testUploadPostJsonBase64()
+    {
+        $client = static::createClient();
+        $binary = file_get_contents(BaseTest::JPG_TEST_IMAGE);
+        $payload = json_encode(['base64' => base64_encode($binary)]);
+        $client->request(
+            'POST',
+            '/upload/w_60,o_png',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            $payload
+        );
+        $this->assertTrue($client->getResponse()->isOk());
+        $this->assertFalse($client->getResponse()->isEmpty());
+    }
+
+    /** Ensure GET /upload with data URI works. */
+    public function testUploadGetDataUri()
+    {
+        $client = static::createClient();
+        $binary = file_get_contents(BaseTest::PNG_TEST_IMAGE);
+        $dataUri = 'data:image/png;base64,' . base64_encode($binary);
+        $client->request('GET', '/upload/w_40,o_jpg/' . $dataUri);
+        $this->assertTrue($client->getResponse()->isOk());
+        $this->assertFalse($client->getResponse()->isEmpty());
+    }
+
+    /** Ensure s3:// without configuration throws AppException. */
+    public function testUploadS3WithoutConfig()
+    {
+        $this->expectException(AppException::class);
+        $client = static::createClient();
+        $client->request('GET', '/upload/w_20/' . 's3://nonexistent-bucket/path/to/image.png');
+    }
+
     public function testUploadActionWithFaceDetection()
     {
         $client = static::createClient();
@@ -96,9 +148,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertFalse($client->getResponse()->isEmpty());
     }
 
-    /**
-     *
-     */
     public function testUploadActionForbidden()
     {
         $this->expectException(ReadFileException::class);
@@ -106,9 +155,6 @@ class DefaultControllerTest extends BaseTest
         $client->request('GET', '/upload/w_200,h_200,c_1/Rovinj-Croatia-nonExist.jpg');
     }
 
-    /**
-     *
-     */
     public function testUploadActionInvalidExtension()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -116,9 +162,6 @@ class DefaultControllerTest extends BaseTest
         $client->request('GET', '/upload/w_200,h_200,c_1,o_xxx/' . BaseTest::JPG_TEST_IMAGE);
     }
 
-    /**
-     *
-     */
     public function testPathAction()
     {
         $client = static::createClient();
@@ -127,9 +170,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertFalse($client->getResponse()->isEmpty());
     }
 
-    /**
-     *
-     */
     public function testPathActionForbidden()
     {
         $this->expectException(ReadFileException::class);
@@ -137,9 +177,6 @@ class DefaultControllerTest extends BaseTest
         $client->request('GET', '/path/w_200,h_200,c_1/Rovinj-Croatia-nonExist.jpg');
     }
 
-    /**
-     *
-     */
     public function testUploadPdfNoPageSpecified()
     {
         $client = static::createClient();
@@ -148,9 +185,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertFalse($client->getResponse()->isEmpty());
     }
 
-    /**
-     *
-     */
     public function testUploadPdfPage2()
     {
         $client = static::createClient();
@@ -159,9 +193,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertFalse($client->getResponse()->isEmpty());
     }
 
-    /**
-     *
-     */
     public function testUploadPdfWithDensity()
     {
         $client = static::createClient();
@@ -170,9 +201,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertFalse($client->getResponse()->isEmpty());
     }
 
-    /**
-     *
-     */
     public function testUploadMovieNoTimeSpecified()
     {
         $client = static::createClient();
@@ -181,9 +209,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertFalse($client->getResponse()->isEmpty());
     }
 
-    /**
-     *
-     */
     public function testUploadMovie5Seconds()
     {
         $client = static::createClient();
@@ -192,9 +217,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertFalse($client->getResponse()->isEmpty());
     }
 
-    /**
-     *
-     */
     public function testUploadMovie10Seconds()
     {
         $client = static::createClient();
@@ -203,9 +225,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertFalse($client->getResponse()->isEmpty());
     }
 
-    /**
-     *
-     */
     public function testUploadMovie10SecondsRefresh()
     {
         $client = static::createClient();
@@ -214,9 +233,6 @@ class DefaultControllerTest extends BaseTest
         $this->assertFalse($client->getResponse()->isEmpty());
     }
 
-    /**
-     *
-     */
     public function testUploadMovie20SecondsFails()
     {
         $this->expectException(ExecFailedException::class);
@@ -231,7 +247,7 @@ class DefaultControllerTest extends BaseTest
      */
     public function createApplication()
     {
-        $app = require __DIR__ . '/../../../app.php';
+        $app = include __DIR__ . '/../../../app.php';
         $app['debug'] = true;
         unset($app['exception_handler']);
 


### PR DESCRIPTION
- Introduced new POST /upload/{options} endpoint for image uploads with raw binary or JSON payloads.
- Enhanced upload functionality to handle data URIs and S3 references.
- Updated routing configuration to include methods for upload endpoints.
- Expanded documentation to cover new upload methods and S3 configuration options.
- Added tests for new upload features, ensuring functionality for various input types.
closes #583 